### PR TITLE
readme: use floppy for qemu!

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -27,7 +27,8 @@ Use this command line:
 
 It can be run with DosBox or qemu:
   
-  qemu-system-x86_64 -hda toledo_atomchess_disk.bin
+  qemu-system-x86_64 -fda toledo_atomchess_disk.bin
+  qemu-system-x86_64 -fda atomr.bin
 
 Thanks to HellMood for suggesting the translation of Toledo
 Atomchess to nasm syntax and some optimization suggestions.


### PR DESCRIPTION
The atom reloaded bin doesn't work for me when starting from hda. Change readme to suggest using `-fda` in qemu to simulate a floppy instead
